### PR TITLE
parameterise the owner and group

### DIFF
--- a/puppet/borrower_frontend/manifests/init.pp
+++ b/puppet/borrower_frontend/manifests/init.pp
@@ -2,7 +2,9 @@
 class borrower_frontend (
     $port = '9000',
     $host = '0.0.0.0',
-    $branch_or_revision = 'master'
+    $branch_or_revision = 'master',
+    $owner = 'vagrant',
+    $group = 'vagrant'
 ) {
   require ::standard_env
 
@@ -11,15 +13,15 @@ class borrower_frontend (
     provider => git,
     source   => 'git://github.com/LandRegistry/charges-borrower-frontend',
     revision => $branch_or_revision,
-    owner    => 'vagrant',
-    group    => 'vagrant',
+    owner    => $owner,
+    group    => $group,
     notify   => Service['borrower_frontend'],
   }
   file { '/opt/borrower-frontend/bin/run.sh':
     ensure  => 'file',
     mode    => '0755',
-    owner   => 'vagrant',
-    group   => 'vagrant',
+    owner   => $owner,
+    group   => $group,
     source  => "puppet:///modules/${module_name}/run.sh",
     require => Vcsrepo['/opt/borrower-frontend'],
     notify  => Service['borrower_frontend'],
@@ -28,22 +30,22 @@ class borrower_frontend (
     ensure  => 'file',
     mode    => '0755',
     content => template("${module_name}/nginx.conf.erb"),
-    owner   => 'vagrant',
-    group   => 'vagrant',
+    owner   => $owner,
+    group   => $group,
     notify  => Service['nginx'],
   }
   file { '/etc/init.d/borrower_frontend':
     ensure => 'file',
     mode   => '0755',
-    owner  => 'vagrant',
-    group  => 'vagrant',
+    owner  => $owner,
+    group  => $group,
     source => "puppet:///modules/${module_name}/borrower_frontend.initd",
   }
   file { '/etc/systemd/system/borrower_frontend.service':
     ensure  => 'file',
     mode    => '0755',
-    owner   => 'vagrant',
-    group   => 'vagrant',
+    owner   => $owner,
+    group   => $group,
     content => template("${module_name}/borrower_frontend_service.erb"),
     notify  => [Exec['systemctl-daemon-reload'], Service['borrower_frontend']],
   }


### PR DESCRIPTION
When running the app in vagrant we would prefer the vagrant user to run
the app, so that when we ssh in we can easily interact with the machine.

When running in the environment we should enable the apps to be run as
their own dedicated user (as old school ops-ers recommend).

To enable this I have parameterised the owner and group and defaulted
them back to vagrant so there is no functional difference.
