### PR TITLE
Add dev host

### DIFF
--- a/acceptance-tests/features/support/env.rb
+++ b/acceptance-tests/features/support/env.rb
@@ -4,7 +4,9 @@
 ### need to change every test when switching environments for example.       ###
 ################################################################################
 
-$BORROWER_FRONTEND_URL = (ENV['BORROWER_FRONTEND_URL'] || 'http://0.0.0.0:9000')
-$DEED_API_URL = (ENV['DEED_API_URL'] || 'http://0.0.0.0:9012')
+$BORROWER_FRONTEND_URL = (
+  ENV['BORROWER_FRONTEND_URL'] || 'http://borrower-frontend.dev.service.gov.uk'
+)
+$DEED_API_URL = (ENV['DEED_API_URL'] || 'http://deedapi.dev.service.gov.uk')
 
 @@TEST_DEEDS = []

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 import os
 
 DEBUG = True
-DEED_API_BASE_HOST = os.getenv('DEED_API_ADDRESS', 'http://localhost:5050')
+DEED_API_BASE_HOST = os.getenv('DEED_API_ADDRESS',
+                               'http://deedapi.dev.service.gov.uk')

--- a/puppet/borrower_frontend/Puppetfile
+++ b/puppet/borrower_frontend/Puppetfile
@@ -1,5 +1,5 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 mod 'LandRegistry/standard_env',
-  :git => 'git://github.com/LandRegistry/standard-env',
-  :ref => 'master'
+    git: 'git://github.com/LandRegistry/standard-env',
+    ref: 'master'

--- a/puppet/borrower_frontend/manifests/init.pp
+++ b/puppet/borrower_frontend/manifests/init.pp
@@ -7,7 +7,7 @@ class borrower_frontend (
     $group = 'vagrant',
     $subdomain = 'borrower-frontend',
     $domain = undef,
-    $deed_api_address = 'http://localhost:5050'
+    $deed_api_address = 'http://deedapi.dev.service.gov.uk'
 ) {
   require ::standard_env
 

--- a/puppet/borrower_frontend/manifests/init.pp
+++ b/puppet/borrower_frontend/manifests/init.pp
@@ -5,6 +5,8 @@ class borrower_frontend (
     $branch_or_revision = 'master',
     $owner = 'vagrant',
     $group = 'vagrant',
+    $subdomain = 'borrower-frontend',
+    $domain = undef,
     $deed_api_address = 'http://localhost:5050'
 ) {
   require ::standard_env
@@ -66,5 +68,8 @@ class borrower_frontend (
       File['/etc/systemd/system/borrower_frontend.service'],
       File['/var/run/borrower_frontend'],
     ],
+  }
+  if $environment == 'development' {
+    standard_env::dev_host { $subdomain: }
   }
 }

--- a/puppet/borrower_frontend/templates/nginx.conf.erb
+++ b/puppet/borrower_frontend/templates/nginx.conf.erb
@@ -1,6 +1,10 @@
 server {
   listen 80;
-  server_name sign.*;
+  <% if @domain %>
+    server_name <%= @domain %>;
+  <% else %>
+    server_name <%= @subdomain %>.*;
+  <% end %>
 
   location / {
     proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
This pull request adds a host entry for the borrower frontend to development deploys of the app and changes the acceptance tests to point to that new host.

The intention is to make the process of developing easier by not having to hoke around for port numbers and IPs.
